### PR TITLE
remove scoverage enabled by default and some dependencies

### DIFF
--- a/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
@@ -51,9 +51,7 @@ object CommonConfigPlugin extends AutoPlugin {
   }
 
   object CommonScoverage {
-    lazy val settings = ScoverageSbtPlugin.projectSettings ++ Seq[Setting[_]](
-      ScoverageKeys.coverageEnabled := true
-    )
+    lazy val settings = ScoverageSbtPlugin.projectSettings   
   }
 
   object CommonDependencies {
@@ -61,8 +59,6 @@ object CommonConfigPlugin extends AutoPlugin {
     lazy val settings = Seq[Setting[_]](
 
       libraryDependencies ++= Seq(
-        "joda-time" % "joda-time" % "2.8.2",
-        "org.slf4j" % "slf4j-simple" % slf4j_version,
         "org.slf4j" % "slf4j-api" % slf4j_version,
         "com.typesafe" % "config" % "1.3.0"
       )


### PR DESCRIPTION
### Description

* ``scoverage`` enabled by default setting removed, refer to [this](https://github.com/scoverage/sbt-scoverage/issues/115) issue.
* ``joda-time`` dependency removed as we tend to use __Java 8 Date and Time__.
* ``slf4j-simple`` logging backend dependency removed, we give the ability to control the logging backend to the project that uses this plugin.

### Review
* [x] Ready for review.