### PR TITLE
Add ReleaseInfoPlugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,6 +44,8 @@ addSbtPlugin("org.scalameta" % "sbt-scalafmt" % "2.2.1")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "1.0.0")
 
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
+
 publishMavenStyle := true
 publishArtifact in Test := false
 pomIncludeRepository := { _ =>

--- a/src/main/scala/com/trueconnectivity/buildinfo/ReleaseVersionKeys.scala
+++ b/src/main/scala/com/trueconnectivity/buildinfo/ReleaseVersionKeys.scala
@@ -1,0 +1,10 @@
+package com.trueconnectivity.buildinfo
+
+import java.io.File
+
+import sbt._
+
+object ReleaseVersionKeys {
+  val releaseVersion = settingKey[String]("Application release version (to be used as docker tag)")
+  val releaseVersionFile = taskKey[File]("Generate .release_version file in build root")
+}

--- a/src/main/scala/com/trueconnectivity/buildinfo/ReleaseVersionPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/buildinfo/ReleaseVersionPlugin.scala
@@ -1,0 +1,43 @@
+package com.trueconnectivity.buildinfo
+
+import java.nio.charset.StandardCharsets
+import java.time.LocalDate
+import java.time.format.DateTimeFormatter
+
+import sbt.{Def, _}
+import Keys._
+import com.trueconnectivity.buildinfo.ReleaseVersionKeys._
+import com.typesafe.sbt.SbtGit.GitKeys.{gitCurrentBranch, gitHeadCommit, gitUncommittedChanges}
+import sbtbuildinfo.BuildInfoPlugin.autoImport.{BuildInfoKey, BuildInfoOption, buildInfoKeys, buildInfoOptions, buildInfoPackage}
+import sbtbuildinfo._
+
+object ReleaseVersionPlugin extends AutoPlugin {
+  private val GIT_SHORT_HASH_LENGTH = 7
+
+  // no trigger - must be enabled explicitly
+  override def requires: Plugins = BuildInfoPlugin
+
+  override def projectSettings: Seq[Def.Setting[_]] = Seq(
+    releaseVersion := Seq(
+      Some(LocalDate.now().format(DateTimeFormatter.ofPattern("yyyyMMdd"))),
+      gitHeadCommit.value.map(_.take(GIT_SHORT_HASH_LENGTH)),
+      Some(gitCurrentBranch.value.filter(_.isLetterOrDigit)),
+      if (gitUncommittedChanges.value) Some("SNAPSHOT") else None
+    ).collect {
+      case Some(segment) => segment
+    }.mkString("-"),
+
+    buildInfoPackage := "com.trueconnectivity.build",
+    buildInfoKeys := Seq[BuildInfoKey](releaseVersion, scalaVersion),
+    buildInfoOptions += BuildInfoOption.ToMap,
+
+    releaseVersionFile := {
+      val targetFile = baseDirectory.value / ".release_version"
+      IO.write(targetFile, releaseVersion.value.getBytes(StandardCharsets.UTF_8))
+      targetFile
+    },
+
+    (Compile / resourceGenerators) += releaseVersionFile.taskValue.map(Seq(_))
+  )
+
+}


### PR DESCRIPTION
When enabled on an application project, generates `com.trueconnectivity.build.BuildInfo` object which allows to refer to `releaseVersion` at runtime:

```
case object BuildInfo {
  val releaseVersion: String = "20200317-7700f45-master-SNAPSHOT"
  val scalaVersion: String = "2.12.10"
  val toMap: Map[String, Any] = Map[String, Any](
    "releaseVersion" -> releaseVersion,
    "scalaVersion" -> scalaVersion)
}
```

and `.release_version` file (in the root directory - to be read in the Jenkinsfile)