### PR TITLE
E2e bug fix

### DIFF
--- a/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
@@ -27,19 +27,27 @@ object CommonConfigPlugin extends AutoPlugin {
 
   object CommonScalastyle {
 
-    lazy val integrationTestScalastyle    = taskKey[Unit]("integrationTestScalastyle")
-    lazy val testScalastyle    = taskKey[Unit]("testScalastyle")
-    lazy val compileScalastyle = taskKey[Unit]("compileScalastyle")
+    lazy val integrationTestScalastyle = taskKey[Unit]("integrationTestScalastyle")
+    lazy val testScalastyle            = taskKey[Unit]("testScalastyle")
+    lazy val compileScalastyle         = taskKey[Unit]("compileScalastyle")
 
-    //Running scalastyle automatically on both compile and test
+    lazy val integrationTestSettings = if (project.configurations.contains(IntegrationTest)) {
+      Seq(
+        integrationTestScalastyle in ThisBuild := scalastyle.in(IntegrationTest).toTask("").value,
+        (compile in IntegrationTest) := ((compile in IntegrationTest) dependsOn integrationTestScalastyle).value
+      )
+    } else {
+      Nil
+    }
+
     lazy val settings = ScalastylePlugin.projectSettings ++ Seq(
-      integrationTestScalastyle in ThisBuild := scalastyle.in(IntegrationTest).toTask("").value,
-      testScalastyle in ThisBuild := scalastyle.in(Test).toTask("").value,
-      compileScalastyle in ThisBuild := scalastyle.in(Compile).toTask("").value,
-      (test in Test) := ((test in Test) dependsOn testScalastyle).value,
-      (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value
-    )
+        testScalastyle in ThisBuild := scalastyle.in(Test).toTask("").value,
+        compileScalastyle in ThisBuild := scalastyle.in(Compile).toTask("").value,
+        (test in Test) := ((test in Test) dependsOn testScalastyle).value,
+        (compile in Compile) := ((compile in Compile) dependsOn compileScalastyle).value
+      ) ++ integrationTestSettings
   }
+
 
   object CommonScoverage {
     lazy val settings = ScoverageSbtPlugin.projectSettings

--- a/src/main/scala/com/trueconnectivity/e2e/E2eTestKeys.scala
+++ b/src/main/scala/com/trueconnectivity/e2e/E2eTestKeys.scala
@@ -3,7 +3,7 @@ package com.trueconnectivity.e2e
 import sbt._
 
 trait E2eTestKeys {
-  val dockerConnectPort         = settingKey[Int]("Applications exposed docker port")
-  val dockerConnectRetryCount   = settingKey[Int]("Number of tries to successfully connect to the application")
-  val dockerConnectRetryDelayMs = settingKey[Int]("Connection retry delay in millis")
+  val e2eConnectPort         = settingKey[Int]("Applications exposed docker port")
+  val e2eConnectRetryCount   = settingKey[Int]("Number of tries to successfully connect to the application")
+  val e2eConnectRetryDelayMs = settingKey[Int]("Connection retry delay in millis")
 }

--- a/src/main/scala/com/trueconnectivity/e2e/E2eTestPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/e2e/E2eTestPlugin.scala
@@ -29,9 +29,9 @@ object E2eTestPlugin extends AutoPlugin {
         .getAbsolutePath,
       testCasesPackageTask := {
         HealthCheck.waitUntilHealthy(
-          dockerConnectPort.value,
-          dockerConnectRetryCount.value,
-          dockerConnectRetryDelayMs.value
+          e2eConnectPort.value,
+          e2eConnectRetryCount.value,
+          e2eConnectRetryDelayMs.value
         )
 
         (sbt.Keys.packageBin in IntegrationTest).value
@@ -49,8 +49,8 @@ object E2eTestPlugin extends AutoPlugin {
   }
 
   override lazy val projectSettings: Seq[Setting[_]] = Seq(
-    dockerConnectRetryCount := 10,
-    dockerConnectRetryDelayMs := 4000,
+    e2eConnectRetryCount := 10,
+    e2eConnectRetryDelayMs := 4000,
   ) ++ Defaults.itSettings ++ DockerComposePlugin.projectSettings ++ E2eConfig.settings
 
   override lazy val buildSettings: Seq[Setting[_]] = Seq()

--- a/src/main/scala/com/trueconnectivity/e2e/E2eTestPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/e2e/E2eTestPlugin.scala
@@ -28,7 +28,11 @@ object E2eTestPlugin extends AutoPlugin {
         .value
         .getAbsolutePath,
       testCasesPackageTask := {
-        HealthCheck.waitUntilHealthy(dockerConnectPort.value, dockerConnectRetryCount.value, dockerConnectRetryDelayMs.value)
+        HealthCheck.waitUntilHealthy(
+          dockerConnectPort.value,
+          dockerConnectRetryCount.value,
+          dockerConnectRetryDelayMs.value
+        )
 
         (sbt.Keys.packageBin in IntegrationTest).value
       },


### PR DESCRIPTION
Only apply scala format to integration test config when present

rename variables so they read better in build.sbt