### PR TITLE
Enable `-Ywarn-used` scalac option

### DIFF
--- a/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
+++ b/src/main/scala/com/trueconnectivity/CommonConfigPlugin.scala
@@ -75,6 +75,7 @@ object CommonConfigPlugin extends AutoPlugin {
         "-Ywarn-dead-code",
         "-Ywarn-adapted-args",
         "-Ywarn-inaccessible",
+        "-Ywarn-unused",
         "-unchecked"
       ),
       scalacOptions in Test ++= Seq(


### PR DESCRIPTION
Enabling unused warnings. Primarily so that [scalameta/metals](https://scalameta.org/metals) will present unused warnings in editors using LSP clients (e.g. VSCode or Vim). It's also a requirement for [scalafix](https://scalacenter.github.io/scalafix/) and we've previously discussed adding that to this common-config-plugin to organize imports on compile.  