### PR TITLE
DCG-3366 Docker Compose / sbt plugin tests fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.9.0")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.7.6")
 
-addSbtPlugin("com.tapad" % "sbt-docker-compose" % "1.0.35")
+addSbtPlugin("com.trueconnectivity" % "sbt-docker-compose" % "1.0.37")
 
 publishMavenStyle := true
 Test / publishArtifact := false


### PR DESCRIPTION
Can be tested with:

`addSbtPlugin("com.trueconnectivity" % "common-config-plugin" % "0.5.30-SNAPSHOT+2-DCG-3366")`

and running the compose tests (with docker-compose 2 installed)